### PR TITLE
lower demanded version of meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'fast_ctd',
   'cpp',
   version: '0.1.0',
-  meson_version: '>= 1.8.0'
+  meson_version: '>= 1.3.0'
 )
 
 # Compilers

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'fast_ctd',
   'cpp',
   version: '0.1.0',
-  meson_version: '>= 1.3.0'
+  meson_version: '>= 1.3.1'
 )
 
 # Compilers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license         = { text = 'GPL-2.0' }
 [project.optional-dependencies]
 dev = [
   "meson-python",
-  "meson>=1.8.0",
+  "meson>=1.3.1",
   "pre-commit",
   "pytest>=8.3.5",
   "pytest-cov>=6.1.1",
@@ -18,7 +18,7 @@ dev = [
 
 [build-system]
 build-backend = 'mesonpy'
-requires      = ['meson-python', 'meson>=1.8.0']
+requires      = ['meson-python', 'meson>=1.3.1']
 
 [tool.ruff.lint]
 pydocstyle.convention = "google"


### PR DESCRIPTION
This means that it can now run on e.g. debian stable as well where the standard meson version is 1.3.2